### PR TITLE
Expose FilterSparseFields helper.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.test
 .idea
 *.coverprofile
+*.out


### PR DESCRIPTION
This function returns a document with only the specific fields in the response on a per-type basis. In error conditions, the 2nd and third response objects are used to articulate a rich error indicating which fields requested for filtering were invalid.

https://jsonapi.org/format/#fetching-sparse-fieldsets